### PR TITLE
Don't include non-system crypto module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "browserify": "^5.9.3",
-    "crypto": "~0.0.3",
     "data-uri-to-buffer": "~0.0.3",
     "fingerprintjs": "~0.5.3",
     "glitcher": "~1.8.1",


### PR DESCRIPTION
The one in NPM is real old, using the system module (which has the same API for the things used here) should be better.
