### PR TITLE
Use JPEG for client posting instead of PNG.

### DIFF
--- a/lib/convert2webm.js
+++ b/lib/convert2webm.js
@@ -17,7 +17,6 @@ var IMAGE_FORMAT = 'png';
 exports.transform = function (mediaArr, next) {
   // write images to tmp files
   var mediaId = uuid.v4();
-  var ended = false;
   var video = new Buffer(0);
   var count = 0;
 
@@ -40,7 +39,7 @@ exports.transform = function (mediaArr, next) {
 
   var writeWebm = function () {
     child.exec('ffmpeg -i "' + TMP_DIR + mediaId +
-      '-%d.' + IMAGE_FORMAT + '" -filter:v "setpts=2.0*PTS" -c:v libtheora -c:a libvorbis -q:v 10 -q:a 10 "' +
+      '-%d.' + IMAGE_FORMAT + '" -filter:v "setpts=2.0*PTS" -c:v libtheora -an -q:v 10 "' +
       TMP_DIR + mediaId + '.' + VIDEO_FORMAT + '"', { timeout: 3000 },
       function (err, stdout, stderr) {
 
@@ -68,35 +67,32 @@ exports.transform = function (mediaArr, next) {
     });
   };
 
-  mediaArr.forEach(function (frame) {
-    setImmediate(function () {
-      var buffer = dataURIBuffer(frame);
+  mediaArr.forEach(function (frame, index) {
+    var buffer = dataURIBuffer(frame);
 
-      readimage(buffer, function (err, image) {
-        if (err) {
+    readimage(buffer, function (err, image) {
+      if (err) {
+        next(err);
+        deleteFiles();
+        return;
+      }
+
+      glitcher.smearChannel(image.frames[0].data, 200, (Math.random() * 8) | 0);
+
+      writepng(image, function (err, newBuffer) {
+        var writeStream = fs.createWriteStream(TMP_DIR + mediaId + '-' + index + '.' + IMAGE_FORMAT);
+
+        writeStream.on('error', function (err) {
           next(err);
           deleteFiles();
           return;
-        }
+        });
 
-        glitcher.smearChannel(image.frames[0].data, 200, (Math.random() * 8) | 0);
-
-        writepng(image, function (err, newBuffer) {
-          var writeStream = fs.createWriteStream(TMP_DIR + mediaId + '-' + count + '.' + IMAGE_FORMAT);
+        writeStream.end(newBuffer, function () {
           count ++;
-
-          writeStream.write(newBuffer);
-          writeStream.on('error', function (err) {
-            next(err);
-            deleteFiles();
-            return;
-          });
-
-          writeStream.end(function () {
-            if (count === mediaArr.length) {
-              writeWebm(next);
-            }
-          });
+          if (count === mediaArr.length) {
+            writeWebm(next);
+          }
         });
       });
     });

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -14,7 +14,7 @@ rtc = new Webrtc2images({
   height: 150,
   frames: 10,
   type: 'image/jpeg',
-  quality: 0.7,
+  quality: 0.9,
   interval: 200
 });
 


### PR DESCRIPTION
This leaves the glitch -> PNG step intact, so ffmpeg is still dealing with PNGs. This also fixes a number of bugs in the media conversion process, and removes unnecessary setImmediate calls.

Saves a ton of upload for clients: ~950k per recording with PNG to ~130k with JPEG. We could probably bump the quality up even more if desired, but this seems relatively similar to the PNG results.
