### PR TITLE
Add autolink util function to link urls w/o protocol

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -35,6 +35,17 @@ var validateImageType = function (data, next) {
   next(null, true);
 };
 
+/**
+ * Default twitter.autoLink behavior is to _not_ link
+ * urls without protocol, with no way to override
+ * https://github.com/twitter/twitter-text-js/blob/master/twitter-text.js#L759
+ * And: https://github.com/twitter/twitter-text-js/issues/136
+ */
+var autoLink = function(text, options) {
+  var entities = twitter.extractEntitiesWithIndices(text, { extractUrlsWithoutProtocol: true });
+  return twitter.autoLinkEntities(text, entities, options);
+};
+
 exports.recent = function (socket) {
   publico.getChats(true, function (err, c) {
     if (err) {
@@ -67,7 +78,7 @@ exports.addMessage = function (payload, next) {
         return;
       }
 
-      var message = twitter.autoLink(twitter.htmlEscape(payload.message), {
+      var message = autoLink(twitter.htmlEscape(payload.message), {
         targetBlank: true
       });
 


### PR DESCRIPTION
twitter-text seems like they have no way of autoLinking to include URLs with no protocl as of now, so this mini hack does the job for the time. Keeping an eye on [my PR](https://github.com/twitter/twitter-text-js/issues/136) and will update here if that situtation changes. 
