### PR TITLE
Truncate message at 250 characters before HTML-escaping and linking

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -67,11 +67,11 @@ exports.addMessage = function (payload, next) {
         return;
       }
 
-      var message = twitter.autoLink(twitter.htmlEscape(payload.message), {
+      var message = twitter.autoLink(twitter.htmlEscape(payload.message.slice(0, 250)), {
         targetBlank: true
       });
 
-      publico.addChat(message.slice(0, 250), {
+      publico.addChat(message, {
         ttl: 600000,
         media: media,
         fingerprint: payload.fingerprint


### PR DESCRIPTION
Fixes https://github.com/meatspaces/meatspace-chat-v2/issues/45

The message is still truncated for length, but now its done before the autoLinking by the Twitter Text library, so that none of the message is lost.
