### PR TITLE
Don't HTML escape entities identified by twitter-text-js, such as links

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -78,7 +78,8 @@ exports.addMessage = function (payload, next) {
         return;
       }
 
-      var message = autoLink(twitter.htmlEscape(payload.message.slice(0, 250)), {
+      var message = autoLink(payload.message.slice(0, 250), {
+        htmlEscapeNonEntities: true,
         targetBlank: true
       });
 


### PR DESCRIPTION
This will avoid the insertion of `&amp;`s in both the link text and the link's href generated but twitter.autoLink()

You can see some of my experimentation with this at http://requirebin.com/?gist=4f0fe3994b1e9d100aa6, I believe this will still prevent a user from injecting HTML, the entity identification seems very strict.
