### PR TITLE
Dual encode for H264 and WebM, emit to respective socket io rooms

### DIFF
--- a/lib/convert2webm.js
+++ b/lib/convert2webm.js
@@ -6,25 +6,25 @@ var child = require('child_process');
 var uuid = require('uuid');
 var dataURIBuffer = require('data-uri-to-buffer');
 var glob = require('glob');
+var async = require('async');
 
 var TMP_DIR = __dirname + '/../tmp/';
 var IMAGE_FORMAT = 'jpg';
 
-exports.transform = function (videoType, mediaArr, next) {
+exports.transform = function (mediaArr, next) {
   // write images to tmp files
   var mediaId = uuid.v4();
-  var video = new Buffer(0);
   var count = 0;
 
   var deleteFiles = function () {
-    glob(TMP_DIR + mediaId + '*', function(err, files) {
+    glob(TMP_DIR + mediaId + '*', function (err, files) {
       if (err) {
         console.log('glob error: ', err);
         return;
       }
 
-      files.forEach(function(file) {
-        fs.unlink(file, function(err) {
+      files.forEach(function (file) {
+        fs.unlink(file, function (err) {
           if (err) {
             console.log('error unlinking ' + file + ':', err);
           }
@@ -33,42 +33,64 @@ exports.transform = function (videoType, mediaArr, next) {
     });
   };
 
-  var writeVideo = function (videoType) {
-    var videoFormat = 'webm';
-    var ffmpegArgs = '" -filter:v "setpts=2.5*PTS" -vcodec libvpx -an "';
+  var writeVideo = function () {
+    var types = [{
+      format: 'webm',
+      ffmpegArgs: '" -filter:v "setpts=2.5*PTS" -vcodec libvpx -an "'
+    }, {
+      format: 'mp4',
+      ffmpegArgs: '" -filter:v "setpts=2.5*PTS" -c:v libx264 -r 30 -pix_fmt yuv420p "'
+    }];
 
-    if (videoType && videoType === 'h264') {
-      videoFormat = 'mp4';
-      ffmpegArgs = '" -filter:v "setpts=2.0*PTS" -c:v libx264 -r 30 -pix_fmt yuv420p "';
-    }
+    async.map(types, function (type, callback) {
+      var video = new Buffer(0);
+      var command = [
+        'ffmpeg -i "',
+        TMP_DIR + mediaId + '-%d.' + IMAGE_FORMAT,
+        type.ffmpegArgs,
+        TMP_DIR + mediaId + '.' + type.format,
+        '"'
+      ].join('');
 
-    child.exec('ffmpeg -i "' + TMP_DIR + mediaId +
-      '-%d.' + IMAGE_FORMAT + ffmpegArgs +
-      TMP_DIR + mediaId + '.' + videoFormat + '"', { timeout: 3000 },
-      function (err, stdout, stderr) {
+      child.exec(command, { timeout: 3000 }, function (err, stdout, stderr) {
+        if (err) {
+          callback(err);
+        }
+
+        var filename = TMP_DIR + mediaId + '.' + type.format;
+        var readStream = fs.createReadStream(filename);
+
+        readStream.on('data', function (chunk) {
+          video = Buffer.concat([video, chunk]);
+        });
+
+        readStream.on('error', function (err) {
+          callback(err);
+        });
+
+        readStream.on('end', function () {
+          var base64 = video.toString('base64');
+          callback(null, {
+            format: type.format,
+            data: 'data:video/' + type.format + ';base64,' + base64
+          });
+        });
+      });
+    }, function (err, results) {
+      var videos = {};
 
       if (err) {
         next(err);
-        deleteFiles();
-        return;
+      }
+      else {
+        results.forEach(function (result) {
+          videos[result.format] = result.data;
+        });
+        next(null, videos);
       }
 
-      var readStream = fs.createReadStream(TMP_DIR + mediaId + '.' + videoFormat);
-
-      readStream.on('data', function (chunk) {
-        video = Buffer.concat([video, chunk]);
-      });
-
-      readStream.on('error', function (err) {
-        next(err);
-        deleteFiles();
-      });
-
-      readStream.on('end', function () {
-        next(null, 'data:video/' + videoFormat + ';base64,' + video.toString('base64'));
-        deleteFiles();
-      });
-    });
+      deleteFiles();
+    })
   };
 
   for (var i = 0; i < mediaArr.length; i ++) {
@@ -92,7 +114,7 @@ exports.transform = function (videoType, mediaArr, next) {
     writeStream.end(buffer, function () {
       count ++;
       if (count === mediaArr.length) {
-        writeVideo(videoType, next);
+        writeVideo();
       }
     });
   }

--- a/lib/services.js
+++ b/lib/services.js
@@ -46,7 +46,7 @@ var autoLink = function(text, options) {
   return twitter.autoLinkEntities(text, entities, options);
 };
 
-exports.recent = function (socket) {
+exports.recent = function (socket, format) {
   publico.getChats(true, function (err, c) {
     if (err) {
       console.log(err);
@@ -58,9 +58,8 @@ exports.recent = function (socket) {
     }
 
     c.chats.forEach(function (chat) {
-      setImmediate(function () {
-        socket.emit('message', chat.value);
-      });
+      chat.value.media = chat.value.media[format];
+      socket.emit('message', chat.value);
     });
   });
 };
@@ -72,7 +71,7 @@ exports.addMessage = function (payload, next) {
       return;
     }
 
-    convert2webm.transform(payload.videoType, payload.media, function (err, media) {
+    convert2webm.transform(payload.media, function (err, media) {
       if (err) {
         next(err);
         return;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "gulp & nodemon index.js"
   },
   "dependencies": {
+    "async": "^0.9.0",
     "browserify": "^5.9.3",
     "data-uri-to-buffer": "~0.0.3",
     "fingerprintjs": "~0.5.3",

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -144,3 +144,7 @@ socket.on('active', function (data) {
 socket.on('message', function (data) {
   services.getMessage(data, mutedFP, profile, messages);
 });
+
+socket.on('connect', function () {
+  socket.emit('join', 'webm');
+});

--- a/public/js/services.js
+++ b/public/js/services.js
@@ -19,8 +19,7 @@ exports.sendMessage = function (profile, rtc, next) {
         message: comment.val(),
         media: frames,
         ip: profile.ip,
-        fingerprint: profile.fingerprint,
-        videoType: 'webm'
+        fingerprint: profile.fingerprint
       }));
     }
 


### PR DESCRIPTION
Both media formats are encoded and stored in the Publico instance.
At the time chats are pulled from Publico and emitted to the client
they exctract the media format and broadcast only that format to
a socket.io "room" by the same name as the format.

Clients now emit an event, "join", with the format they wish to
receive. The initial chat dump occurs on this join event instead
of connection. Room names at this time are "webm" and "mp4".
