### PR TITLE
Restrict visibility change play/pauses to in-view videos

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -123,7 +123,7 @@ messages.on('click', '.mute', function (ev) {
 
 doc.on('visibilitychange', function (ev) {
   var hidden = document.hidden;
-  $('video').each(function () {
+  $('.in-view video').each(function () {
     if (hidden) {
       this.pause();
     } else {


### PR DESCRIPTION
Currently whenever you tab away from Meatspace then tab back, all of the out-of-view videos start playing again.
