### PR TITLE
Add level key as id property for onMessage payload

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -44,6 +44,7 @@ exports.recent = function (socket, format) {
     }
 
     for (var i = c.chats.length - 1; i >= 0; i--) {
+      c.chats[i].value.key = c.chats[i].key;
       c.chats[i].value.media = c.chats[i].value.media[format];
       socket.emit('message', c.chats[i].value);
     }


### PR DESCRIPTION
This adds the leveldb key into the payload as "id" so clients can de-dupe messages. There may ultimately be a better way to structure this payload as @tec27 and I were talking about, but this seems like an easy fix that doesn't break anything for right now, so let me know what you all think.

The resulting payload for `on('message')` will look like this:

```
{
  created: 1413285032074,
  fingerprint: "4475e3b8d6da4b21b99a83c9ccb8fc46",
  id: "1413285032074!5915a31f-cac0-40b8-8854-c9210046266f",
  media: "data:video/webm;base64,GkXfowEAAA...",
  message: "an example message hi",
  owner: false,
  ttl: 600000
}
```
