### PR TITLE
Change chat data structure back to key/value object from publico

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,11 +131,11 @@ server.start(function () {
         }
 
         socket.emit('messageack', null, ackData);
-        var videoData = chat.media;
+        var videoData = chat.value.media;
         var formats = ['webm', 'mp4'];
 
         formats.forEach(function (format) {
-          chat.media = videoData[format];
+          chat.value.media = videoData[format];
           io.sockets.in(format).emit('message', chat);
         });
       });

--- a/lib/services.js
+++ b/lib/services.js
@@ -45,7 +45,7 @@ exports.recent = function (socket, format) {
 
     for (var i = c.chats.length - 1; i >= 0; i--) {
       c.chats[i].value.media = c.chats[i].value.media[format];
-      socket.emit('message', c.chats[i].value);
+      socket.emit('message', c.chats[i]);
     }
   });
 };
@@ -78,7 +78,7 @@ exports.addMessage = function (payload, next) {
           return;
         }
 
-        next(null, chat);
+        next(null, { key: chat.key, value: chat });
       });
     });
   });

--- a/public/js/services.js
+++ b/public/js/services.js
@@ -31,24 +31,24 @@ exports.getMessage = function (data, mutedFP, userIdManager, profile, messages) 
     window.ga('send', 'event', 'message', 'receive');
   }
 
-  if (!mutedFP[data.fingerprint]) {
-    var li = $('<li data-fp="' + data.fingerprint + '" />');
+  if (!mutedFP[data.value.fingerprint]) {
+    var li = $('<li data-fp="' + data.value.fingerprint + '" />');
     var videoContainer = $('<div class="video-container"/>');
-    var video = $('<video src="' + data.media + '" autoplay="autoplay" loop />');
+    var video = $('<video src="' + data.value.media + '" autoplay="autoplay" loop />');
     var convertButton = $('<a class="convert">Save as GIF</a>');
     var p = $('<p />');
     var userControls = '';
 
-    if (!userIdManager.contains(data.fingerprint)) {
+    if (!userIdManager.contains(data.value.fingerprint)) {
       userControls = '<button class="mute">mute</button>';
     }
 
-    var created = moment(new Date(data.created));
+    var created = moment(new Date(data.value.created));
     var time = $('<time datetime="' + created.toISOString() + '" class="timestamp">' +
       created.format('LT') + '</time>');
 
     var actions = $('<div class="actions">' + userControls +'</div>');
-    p.html(data.message);
+    p.html(data.value.message);
     videoContainer.append(video).append(convertButton);
     li.append(videoContainer).append(p).append(actions);
     messages.append(li);


### PR DESCRIPTION
This is the breaking api option as an **alternative** to https://github.com/meatspaces/meatspace-chat-v2/pull/60 like @tec27 was referring to. It seemed pretty easy so I may be missing places that need updates, but overall this is probably cleaner in the backend, a little messier for the client to be calling `data.value.<prop>` everywhere.
