### PR TITLE
Increase the maximum allowed jpeg filesize.

### DIFF
--- a/lib/convert2video.js
+++ b/lib/convert2video.js
@@ -105,7 +105,7 @@ exports.transform = function (mediaArr, next) {
 
   for (var i = 0; i < mediaArr.length; i ++) {
     var frame = mediaArr[i];
-    if (frame.length > 10000 * 4 / 3) {
+    if (frame.length > 15000 * 4 / 3) {
       return done(new Error('File too large'));
     }
 


### PR DESCRIPTION
I was able to get real close to the current limit without trying too
hard (within 1K), so this seems a bit too low. Bumping it up by 50%
still keeps it fairly low and has little effect on anything, but keeps
us safer from discarding legitimate posts.

Fixes #71.
