### PR TITLE
Add sourcemaps to the JS.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,7 @@ gulp.task('static', function(){
 });
 
 gulp.task('js', function(){
-  return browserify('./public/js/main.js')
+  return browserify({ debug: true, entries: [ './public/js/main.js' ] })
     .bundle()
     .pipe(source('bundle.js'))
     .pipe(buffer())


### PR DESCRIPTION
This will distribute sourcemaps in all server configurations, but I
don't think this should really problematic and we're not trying to hide
anything. If anything it will make production issues easier to debug.

Also fixes an issue with later versions of gulp-sourcemaps, which seem
unhappy with sourcemap-less sources.
