### PR TITLE
Upgrade browserify shim to 3.8, resolve unmet peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "webrtc2images": "~1.4.3"
   },
   "devDependencies": {
-    "browserify-shim": "^3.7.0",
+    "browserify-shim": "^3.8.0",
     "gulp": "^3.8.7",
     "gulp-autowatch": "0.0.1",
     "gulp-cached": "^1.0.1",


### PR DESCRIPTION
Doing a fresh `npm install` of this repository resulted in an error due to an unmet peer dependency as a result of the barrage of package upgrades. `browserify-shim@3.7.x` has a peer dependency of `browserify < 6`. The upgrade to browserify 6 broke on this. shim 3.8 ups the peer dependency to `browserify < 7`.
