### PR TITLE
Increase allowable frame size again.

### DIFF
--- a/lib/convert2video.js
+++ b/lib/convert2video.js
@@ -105,7 +105,7 @@ exports.transform = function (mediaArr, next) {
 
   for (var i = 0; i < mediaArr.length; i ++) {
     var frame = mediaArr[i];
-    if (frame.length > 15000 * 4 / 3) {
+    if (frame.length > 30000 * 4 / 3) {
       return done(new Error('File too large'));
     }
 


### PR DESCRIPTION
Certain encoders (especially on mobile devices, it seem) can still
generate somewhat larger files than we're seeing from most browsers.
This limit still puts us below average v1 GIF sizes at most, which we've
seen is fine for this server, and so shouldn't be a problem.
