### PR TITLE
Give composer highest tab index on the page

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -8,5 +8,5 @@ block footer
   .debugger
     p#debug-msg
   form
-    input(type='text', name='message', id='composer-message', maxlength='250', autocomplete='off', autofocus)
+    input(type='text', name='message', id='composer-message', maxlength='250', autocomplete='off', autofocus, tabindex='1')
     #counter


### PR DESCRIPTION
Allows you to tab back to it if you click the list, or click away.

Previously you need to Shift-tab, or click.
