### PR TITLE
Return on error

### DIFF
--- a/lib/convert2video.js
+++ b/lib/convert2video.js
@@ -59,7 +59,7 @@ exports.transform = function (mediaArr, next) {
 
       child.exec(command, { timeout: 3000 }, function (err, stdout, stderr) {
         if (err) {
-          callback(err);
+          return callback(err);
         }
 
         var filename = TMP_DIR + mediaId + '.' + type.format;


### PR DESCRIPTION
If `ffmpeg` fails we should return immediately.
