### PR TITLE
Add option for using TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,25 @@ Everything else: [https://trac.ffmpeg.org/wiki/CompilationGuide](https://trac.ff
     cp local.json-dist local.json
     npm start
 
+## Using TLS
+
+You can configure the server to use TLS by including a `tls` option in `local.json`.  The `tls` option eventually gets passed as the "options" object to [`tls.createServer`](https://nodejs.org/api/tls.html#tls_tls_createserver_options_secureconnectionlistener).
+
+Within the `tls` option, you can either specify `key` and `cert` using the PEM-formatted data of the private key and the certificate, respectively, or `keyFile` and `certFile`, in which case the private key and the certificate will be read from files.
+
+Sample config file:
+
+```
+{
+    "domain": "localhost",
+    "port": 3000,
+    "wsServer": "ws://localhost:3000",
+    "tls": {"keyFile": "key.pem", "certFile": "cert.pem"}
+}
+```
+
+Using TLS can be desirable, since recent versions of Chrome don't allow accessing the camera unless the web site is either accessed as `localhost` or uses TLS.
+
 ## Accessing the API
 
 This is using the latest version of [socket.io](http://socket.io) and will not work with the old version from the previous meatspace API.

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var Hapi = require('hapi');
 var nconf = require('nconf');
 var SocketIO = require('socket.io');
 var crypto = require('crypto');
+var fs = require('fs');
 
 var services = require('./lib/services');
 
@@ -11,7 +12,16 @@ nconf.argv().env().file({ file: 'local.json' });
 
 var users = 0;
 
-var hapiOptions = {tls: nconf.get('tls')};
+var tlsOptions = nconf.get('tls');
+if (tlsOptions) {
+    if ('keyFile' in tlsOptions) {
+	tlsOptions['key'] = fs.readFileSync(tlsOptions['keyFile']);
+    }
+    if ('certFile' in tlsOptions) {
+	tlsOptions['cert'] = fs.readFileSync(tlsOptions['certFile']);
+    }
+}
+var hapiOptions = {tls: tlsOptions};
 var server = Hapi.createServer(nconf.get('domain'), nconf.get('port'), hapiOptions);
 server.views({
   engines: {

--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ nconf.argv().env().file({ file: 'local.json' });
 
 var users = 0;
 
-var server = Hapi.createServer(nconf.get('domain'), nconf.get('port'));
+var hapiOptions = {tls: nconf.get('tls')};
+var server = Hapi.createServer(nconf.get('domain'), nconf.get('port'), hapiOptions);
 server.views({
   engines: {
     jade: require('jade')


### PR DESCRIPTION
Chrome doesn't allow access to the camera for non-localhost non-TLS connections, thus the desire for this option.

Not sure if this is the right way to do it. Any guidance appreciated!
